### PR TITLE
fixing missing arduino:avr dep for adafruit:avr

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -97,6 +97,8 @@ def install_platform(platform):
     print("Installing", platform, end=" ")
     if platform == "adafruit:samd":   # we have a platform dep
         install_platform("arduino:samd")
+    if platform == "adafruit:avr":   # we have a platform dep
+        install_platform("arduino:avr")
     if os.system("arduino-cli core install "+platform+" --additional-urls "+BSP_URLS+" > /dev/null") != 0:
         ColorPrint.print_fail("FAILED to install "+platform)
         exit(-1)


### PR DESCRIPTION
This should fix the `trinket` target. I was able to partially test it locally; it correctly installed the `arduino:avr` core but then failed on something else likely due to my local env not being totally set up to match actions