### PR TITLE
Remove code for unnecessary Adafruit SAMD Boards platform dependency

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -111,8 +111,6 @@ class ColorPrint:
 
 def install_platform(platform):
     print("Installing", platform, end=" ")
-    if platform == "adafruit:samd":   # we have a platform dep
-        install_platform("arduino:samd")
     if platform == "adafruit:avr":   # we have a platform dep
         install_platform("arduino:avr")
     if os.system("arduino-cli core install "+platform+" --additional-urls "+BSP_URLS+" > /dev/null") != 0:


### PR DESCRIPTION
Previously, Arduino SAMD Boards was installed whenever the script was run for one of the Adafruit SAMD Boards.

Adafruit SAMD Boards doesn't have a dependency on Arduino SAMD Boards, so this only slows down the CI run.

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

I removed the code that installs Arduino SAMD Boards whenever the code is being compiled for one of the Adafruit SAMD Boards.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

This change would only cause a problem if Adafruit SAMD Boards changed to having a dependency on Arduino SAMD Boards at some point in the future.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I have tested this in my fork:
https://github.com/per1234/ci-arduino/runs/745991258?check_suite_focus=true#step:5:28
I notice this repository's GitHub Actions workflow [doesn't test the script for any Adafruit boards](https://github.com/adafruit/ci-arduino/blob/master/.github/workflows/githubci.yml#L19). If you would like me to add one of the Adafruit SAMD Boards to the workflow to verify this PR, I'm happy to do so.