### PR TITLE
Fix actions install script

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -18,6 +18,6 @@ mkdir ${HOME}/Arduino/libraries
 
 # install arduino IDE
 export PATH=$PATH:$GITHUB_WORKSPACE/bin
-curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh 2>&1
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.11.0 2>&1
 arduino-cli config init > /dev/null
 arduino-cli core update-index > /dev/null


### PR DESCRIPTION
I've tested this on a fork of this library and locally. Arduino changed the install script, so now it won't work unless you specify the version.