### PR TITLE
Now checks for branch before pushing

### DIFF
--- a/doxy_gen_and_deploy.sh
+++ b/doxy_gen_and_deploy.sh
@@ -141,7 +141,7 @@ if [ ${IS_PULL} == 1 ]; then
     echo "This is a Pull Request, we're done!"
     exit 0
 else
-    echo "This is a Commit, Uploading documentation..."
+    echo "This is a Commit, we may want to upload documentation..."
 fi
 
 cd code_docs/${REPO_NAME}
@@ -151,36 +151,41 @@ cd code_docs/${REPO_NAME}
 # Only upload if Doxygen successfully created the documentation.
 # Check this by verifying that the html directory and the file html/index.html
 # both exist. This is a good indication that Doxygen did it's work.
-if [ -d "html" ] && [ -f "html/index.html" ]; then
+if echo $GITHUB_REF | grep -q 'master\|main'; then
+    if [ -d "html" ] && [ -f "html/index.html" ]; then
 
-    echo 'Uploading documentation to the gh-pages branch...'
-    # Add everything in this directory (the Doxygen code documentation) to the
-    # gh-pages branch.
-    # GitHub is smart enough to know which files have changed and which files have
-    # stayed the same and will only update the changed files.
-    echo 'Adding all files'
-    git add --all
+        echo 'Uploading documentation to the gh-pages branch...'
+        # Add everything in this directory (the Doxygen code documentation) to the
+        # gh-pages branch.
+        # GitHub is smart enough to know which files have changed and which files have
+        # stayed the same and will only update the changed files.
+        echo 'Adding all files'
+        git add --all
 
-    if [ -n "$(git status --porcelain)" ]; then
-    echo "Changes to commit"
+        if [ -n "$(git status --porcelain)" ]; then
+        echo "Changes to commit"
+        else
+        echo "No changes to commit"
+        exit 0
+        fi
+
+        # Commit the added files with a title and description containing the Travis CI
+        # build number and the GitHub commit reference that issued this build.
+        echo 'Git committing'
+        git commit -m "Deploy code docs to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
+
+        # Force push to the remote gh-pages branch.
+        # The ouput is redirected to /dev/null to hide any sensitive credential data
+        # that might otherwise be exposed.
+        echo 'Git pushing'
+        git push --force "https://${AUTH}@github.com/${REPO_SLUG}.git" > /dev/null 2>&1
     else
-    echo "No changes to commit"
-    exit 0
+        echo '' >&2
+        echo 'Warning: No documentation (html) files have been found!' >&2
+        echo 'Warning: Not going to push the documentation to GitHub!' >&2
+        exit 1
     fi
-
-    # Commit the added files with a title and description containing the Travis CI
-    # build number and the GitHub commit reference that issued this build.
-    echo 'Git committing'
-    git commit -m "Deploy code docs to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
-
-    # Force push to the remote gh-pages branch.
-    # The ouput is redirected to /dev/null to hide any sensitive credential data
-    # that might otherwise be exposed.
-    echo 'Git pushing'
-    git push --force "https://${AUTH}@github.com/${REPO_SLUG}.git" > /dev/null 2>&1
 else
-    echo '' >&2
-    echo 'Warning: No documentation (html) files have been found!' >&2
-    echo 'Warning: Not going to push the documentation to GitHub!' >&2
-    exit 1
+    echo "Branch is not master or main, we're done!"
+    exit 0
 fi


### PR DESCRIPTION
Tested on BMP183.

In this case, we were on master and there were changes to commit, so it committed and pushed them to gh-pages.
https://github.com/adafruit/Adafruit_BMP183_Library/runs/855278911?check_suite_focus=true#step:8:13

In this case we are on the branch I made to make the test PR from. As expected, it does not push to gh-pages
https://github.com/adafruit/Adafruit_BMP183_Library/runs/855291221?check_suite_focus=true#step:8:13