### PR TITLE
Resolve warning that will affect Python 3.10 compatibility

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -180,7 +180,7 @@ for arg in sys.argv[1:]:
     platform = ALL_PLATFORMS.get(arg, None)
     if isinstance(platform, str):
         platforms.append(arg)
-    elif isinstance(platform, collections.Iterable):
+    elif isinstance(platform, collections.abc.Iterable):
         for p in platform:
             platforms.append(p)
     else:


### PR DESCRIPTION
I noticed this message during an otherwise successful build of our arduino-CAN fork:
```
/home/runner/work/arduino-CAN/arduino-CAN/ci/build_platform.py:183: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```
This should resolve the problem.
