### PR TITLE
Patch for MetroX Arduino Repo

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -21,8 +21,11 @@ os.environ["PATH"] += os.pathsep + BUILD_DIR + "/bin"
 print("build dir:", BUILD_DIR)
 
 IS_LEARNING_SYS = False
-if "Adafruit_Learning_System_Guides" or "METROX-Examples-and-Project-Sketches" in BUILD_DIR:
+if "Adafruit_Learning_System_Guides" in BUILD_DIR:
     print("Found learning system repo")
+    IS_LEARNING_SYS = True
+elif "METROX-Examples-and-Project-Sketches" in BUILD_DIR:
+    print("Found MetroX Examples Repo")
     IS_LEARNING_SYS = True
 
 #os.system('pwd')

--- a/build_platform.py
+++ b/build_platform.py
@@ -21,7 +21,7 @@ os.environ["PATH"] += os.pathsep + BUILD_DIR + "/bin"
 print("build dir:", BUILD_DIR)
 
 IS_LEARNING_SYS = False
-if "Adafruit_Learning_System_Guides" in BUILD_DIR:
+if "Adafruit_Learning_System_Guides" or "METROX-Examples-and-Project-Sketches" in BUILD_DIR:
     print("Found learning system repo")
     IS_LEARNING_SYS = True
 


### PR DESCRIPTION
Adding patch for allowing the MetroX arduino example repo to use `.deps` to handle dependencies and search for examples within all directory paths, similar to Learning System Guide repository.

Verified working with an active MetroX pull request running against a staged version of the ci script on `brentru/ci-arduino` https://github.com/brentru/METROX-Examples-and-Project-Sketches-1/actions/runs/416213086