### PR TITLE
add feather m4 can to platform list

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -58,6 +58,8 @@ ALL_PLATFORMS={
     "gemma_m0" : "adafruit:samd:adafruit_gemma_m0",
     "trinket_m0" : "adafruit:samd:adafruit_trinket_m0",
     "feather_m0_express" : "adafruit:samd:adafruit_feather_m0_express",
+    "feather_m4_can" : "adafruit:samd:adafruit_feather_m4_can:speed=120",
+    "feather_m4_can_tinyusb" : "adafruit:samd:adafruit_feather_m4_can:speed=120,usbstack=tinyusb",
     "metro_m0" : "adafruit:samd:adafruit_metro_m0",
     "metro_m0_tinyusb" : "adafruit:samd:adafruit_metro_m0:usbstack=tinyusb",
     "metro_m4" : "adafruit:samd:adafruit_metro_m4:speed=120",


### PR DESCRIPTION
add feather m4 can to platform list for ci on library check such as tinyusb arduino