### PR TITLE
add optional --wall option for ci

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -5,10 +5,10 @@ import os
 import subprocess
 import collections
 
-# optional wall option
-BUILD_WARNING = 'default'
+# optional wall option cause build failed if has warnings
+BUILD_WALL = False
 if "--wall" in sys.argv:
-    BUILD_WARNING = 'all'
+    BUILD_WALL = True
     sys.argv.remove("--wall")
 
 # add user bin to path!
@@ -231,13 +231,13 @@ def test_examples_in_folder(folderpath):
             ColorPrint.print_warn("skipping")
             continue
 
-        cmd = ['arduino-cli', 'compile', '--warnings', BUILD_WARNING, '--fqbn', fqbn, examplepath]
+        cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, examplepath]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         r = proc.wait()
         out = proc.stdout.read()
         err = proc.stderr.read()
-        if r == 0:
+        if r == 0 and not (err and BUILD_WALL == True):
             ColorPrint.print_pass(CHECK)
             if err:
                 # also print out warning message
@@ -257,7 +257,7 @@ def test_examples_in_learningrepo(folderpath):
             continue
         if not projectpath.endswith(".ino"):
             continue
-	# found an INO!
+	    # found an INO!
         print('\t'+projectpath, end=' ')
         # check if we should SKIP
         skipfilename = folderpath+"/."+platform+".test.skip"
@@ -269,7 +269,7 @@ def test_examples_in_learningrepo(folderpath):
             ColorPrint.print_warn("skipping")
             continue
 
-        cmd = ['arduino-cli', 'compile', '--warnings', BUILD_WARNING, '--fqbn', fqbn, projectpath]
+        cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, projectpath]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         r = proc.wait()


### PR DESCRIPTION
- update BUILD_DIR to be able to run it locally
- add `pico_rp2040_tinyusb` and `feather_rp2040_tinyusb`
- add optional `--wall` option for build ci
  - The ci now always build with all warnings, in case of `--wall` option is present. warning is counted as error. 
  - Otherwise the build will pass but the warning message is printed so that we could fix it gradually.


 