### PR TITLE
Add Platform - Metro M4 AirLift w/TinyUSB stack

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -77,6 +77,7 @@ ALL_PLATFORMS={
     "metro_m4" : "adafruit:samd:adafruit_metro_m4:speed=120",
     "metro_m4_tinyusb" : "adafruit:samd:adafruit_metro_m4:speed=120,usbstack=tinyusb",
     "metro_m4_airliftlite" : "adafruit:samd:adafruit_metro_m4_airliftlite:speed=120",
+    "metro_m4_airliftlite_tinyusb" : "adafruit:samd:adafruit_metro_m4_airliftlite:speed=120,usbstack=tinyusb",
     "pybadge" : "adafruit:samd:adafruit_pybadge_m4:speed=120",
     "pybadge_tinyusb" : "adafruit:samd:adafruit_pybadge_m4:speed=120,usbstack=tinyusb",
     "pygamer" : "adafruit:samd:adafruit_pygamer_m4:speed=120",


### PR DESCRIPTION
Adding Metro M4 AirLift Lite w/tinyusb stack to platform list.