### PR TITLE
make symlink with library name rather than 'Adafruit_Test_Library'

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -183,13 +183,6 @@ run_or_die("arduino-cli core update-index --additional-urls "+BSP_URLS+
            " > /dev/null", "FAILED to update core indecies")
 print()
 
-# link test library folder to the arduino libraries folder
-if not IS_LEARNING_SYS:
-    try:
-        os.symlink(BUILD_DIR, os.environ['HOME']+'/Arduino/libraries/Adafruit_Test_Library')
-    except FileExistsError:
-        pass
-
 ################################ Install dependancies
 our_name=None
 try:
@@ -217,6 +210,13 @@ if our_name:
     run_or_die("arduino-cli lib uninstall \""+our_name+"\"", "Could not uninstall")
 
 print("Libraries installed: ", glob.glob(os.environ['HOME']+'/Arduino/libraries/*'))
+
+# link our library folder to the arduino libraries folder
+if not IS_LEARNING_SYS:
+    try:
+        os.symlink(BUILD_DIR, os.environ['HOME']+'/Arduino/libraries/' + os.path.basename(BUILD_DIR))
+    except FileExistsError:
+        pass
 
 ################################ Test platforms
 platforms = []


### PR DESCRIPTION
This PR use the same library name when making an symlink to `Arduino/libraries` location. The reason is some libraries is included by core BSP e.g `Adafruit_TinyUSB_Arduino`. Make a symlink with generic name ` Adafruit_Test_Library` will cause arduino-cli pick the one included in BSP due to better name win criteria (Folder Name Priority) when running ci.

CI log 

```
Multiple libraries were found for "Adafruit_TinyUSB.h"
 Used: /home/runner/.arduino15/packages/adafruit/hardware/nrf52/0.24.0/libraries/Adafruit_TinyUSB_Arduino
 Not used: /home/runner/Arduino/libraries/Adafruit_Test_Library
```

Arduino Dependency Resolution

```
If multiple libraries contain a file that matches the #include directive, the priority is determined by applying the following rules, one by one in this order, until a rule determines a winner:

A library that is architecture compatible wins against a library that is not architecture compatible (see Architecture Matching)
A library that has better "folder name priority" wins (see Folder Name Priority)
A library that is architecture optimized wins against a library that is not architecture optimized (see Architecture Matching)
A library that has a better "location priority" wins (see Location Priority)
A library that has a folder name with a better score using the "closest-match" algorithm wins
A library that has a folder name that comes first in alphanumeric order wins
``` 