### PR TITLE
Add support for exporting compiled examples 

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -18,6 +18,7 @@ mkdir ${HOME}/Arduino/libraries
 
 # install arduino IDE
 export PATH=$PATH:$GITHUB_WORKSPACE/bin
-curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.11.0 2>&1
+#curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.11.0 2>&1
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh
 arduino-cli config init > /dev/null
 arduino-cli core update-index > /dev/null

--- a/actions_install.sh
+++ b/actions_install.sh
@@ -18,7 +18,6 @@ mkdir ${HOME}/Arduino/libraries
 
 # install arduino IDE
 export PATH=$PATH:$GITHUB_WORKSPACE/bin
-#curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.11.0 2>&1
-curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.18.3 2>&1
 arduino-cli config init > /dev/null
 arduino-cli core update-index > /dev/null

--- a/build_platform.py
+++ b/build_platform.py
@@ -231,8 +231,8 @@ def generate_uf2(example_path):
     """Generates a .uf2 file from a .bin or .hex file.
     :param str example_path: A path to the compiled .bin or .hex file.
     """
-    if ALL_PLATFORMS[platform][1] == None:
-        return False
+    #if ALL_PLATFORMS[platform][1] == None:
+    #    return False
     # Convert .hex to .uf2
     family_id = ALL_PLATFORMS[platform][1]
     cli_build_path = "build/*.*." + fqbn.split(':')[2] + "/*.hex"

--- a/build_platform.py
+++ b/build_platform.py
@@ -57,8 +57,8 @@ ALL_PLATFORMS={
     "zero" : ["arduino:samd:arduino_zero_native", "0x68ed2b88"],
     "cpx" : ["arduino:samd:adafruit_circuitplayground_m0", "0x68ed2b88"],
     # Espressif
-    "esp8266" : ["esp8266:esp8266:huzzah:eesz=4M3M,xtal=80", "0x7eab61ed"],
-    "esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", "0x1c5f21b0"],
+    "esp8266" : ["esp8266:esp8266:huzzah:eesz=4M3M,xtal=80", None],
+    "esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
     "magtag" : ["esp32:esp32:adafruit_magtag29_esp32s2", "0xbfdd4eee"],
     "funhouse" : ["esp32:esp32:adafruit_funhouse_esp32s2", "0xbfdd4eee"],
     "metroesp32s2" : ["esp32:esp32:adafruit_metro_esp32s2", "0xbfdd4eee"],

--- a/build_platform.py
+++ b/build_platform.py
@@ -230,15 +230,15 @@ def glob1(pattern):
 def generate_uf2(example_path):
     """Generates a .uf2 file from a .bin or .hex file.
     :param str example_path: A path to the compiled .bin or .hex file.
+
     """
-    #if ALL_PLATFORMS[platform][1] == None:
-    #    return False
+    if ALL_PLATFORMS[platform][1] == None:
+        return 1
     # Convert .hex to .uf2
-    ColorPrint.print_bold("generate_uf2")
-    family_id = ALL_PLATFORMS[platform][1]
     cli_build_path = "build/*.*." + fqbn.split(':')[2] + "/*.hex"
     input_file = glob1(os.path.join(example_path, cli_build_path))
     output_file = os.path.splitext(input_file)[0] + ".uf2"
+    family_id = ALL_PLATFORMS[platform][1]
     cmd = ['python3', 'uf2conv.py', input_file, '-c', '-f', family_id, '-o', output_file]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     r = proc.wait(timeout=60)
@@ -246,12 +246,13 @@ def generate_uf2(example_path):
     err = proc.stderr.read()
     if r == 0 and not err:
         ColorPrint.print_pass(CHECK)
+        ColorPrint.print_info(out.decode("utf-8"))
     else:
         ColorPrint.print_fail(CROSS)
         ColorPrint.print_fail(out.decode("utf-8"))
         ColorPrint.print_fail(err.decode("utf-8"))
-        return False
-    return True
+        return 1
+    return 0
 
 ################################ Test platforms
 platforms = []
@@ -326,8 +327,7 @@ def test_examples_in_folder(folderpath):
                 ColorPrint.print_fail(err.decode("utf-8"))
             if os.path.exists(gen_file_name):
                 ColorPrint.print_info("Generating UF2...")
-                #success = generate_uf2(folderpath)
-                generate_uf2(folderpath)
+                success = generate_uf2(folderpath)
         else:
             ColorPrint.print_fail(CROSS)
             ColorPrint.print_fail(out.decode("utf-8"))

--- a/build_platform.py
+++ b/build_platform.py
@@ -212,6 +212,13 @@ if our_name:
 
 print("Libraries installed: ", glob.glob(os.environ['HOME']+'/Arduino/libraries/*'))
 
+# link our library folder to the arduino libraries folder
+if not IS_LEARNING_SYS:
+    try:
+        os.symlink(BUILD_DIR, os.environ['HOME']+'/Arduino/libraries/' + os.path.basename(BUILD_DIR))
+    except FileExistsError:
+        pass
+
 ################################ UF2 Utils.
 
 def glob1(pattern):

--- a/build_platform.py
+++ b/build_platform.py
@@ -326,7 +326,8 @@ def test_examples_in_folder(folderpath):
                 ColorPrint.print_fail(err.decode("utf-8"))
             if os.path.exists(gen_file_name):
                 ColorPrint.print_info("Generating UF2...")
-                success = generate_uf2(folderpath)
+                #success = generate_uf2(folderpath)
+                generate_uf2(folderpath)
         else:
             ColorPrint.print_fail(CROSS)
             ColorPrint.print_fail(out.decode("utf-8"))

--- a/build_platform.py
+++ b/build_platform.py
@@ -258,7 +258,7 @@ def test_examples_in_folder(folderpath):
         if BUILD_WARN:
             cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, examplepath]
         else:
-            cmd = ['arduino-cli', 'compile', '--warnings', 'none', '--fqbn', fqbn, examplepath]
+            cmd = ['arduino-cli', 'compile', '--warnings', 'none', '--export-binaries', '--fqbn', fqbn, examplepath]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         r = proc.wait(timeout=60)

--- a/build_platform.py
+++ b/build_platform.py
@@ -106,6 +106,7 @@ ALL_PLATFORMS={
     "neokeytrinkey_m0" : ["adafruit:samd:adafruit_neokeytrinkey_m0", "0x68ed2b88"],
     "slidetrinkey_m0" : ["adafruit:samd:adafruit_slidetrinkey_m0", "0x68ed2b88"],
     "proxlighttrinkey_m0" : ["adafruit:samd:adafruit_proxlighttrinkey_m0", "0x68ed2b88"],
+    "qtpy_m0" : ["adafruit:samd:adafruit_qtpy_m0", "0x68ed2b88"],
     # Arduino nRF
     "microbit" : ["sandeepmistry:nRF5:BBCmicrobit:softdevice=s110", None],
     # Adafruit nRF

--- a/build_platform.py
+++ b/build_platform.py
@@ -234,6 +234,7 @@ def generate_uf2(example_path):
     #if ALL_PLATFORMS[platform][1] == None:
     #    return False
     # Convert .hex to .uf2
+    ColorPrint.print_bold("generate_uf2")
     family_id = ALL_PLATFORMS[platform][1]
     cli_build_path = "build/*.*." + fqbn.split(':')[2] + "/*.hex"
     input_file = glob1(os.path.join(example_path, cli_build_path))

--- a/build_platform.py
+++ b/build_platform.py
@@ -235,6 +235,7 @@ def generate_uf2(example_path):
     if ALL_PLATFORMS[platform][1] == None:
         ColorPrint.print_fail(CROSS)
         ColorPrint.print_fail("Platform does not support UF2 files, skipping generation...")
+        return
     # Convert .hex to .uf2
     cli_build_path = "build/*.*." + fqbn.split(':')[2] + "/*.hex"
     input_file = glob1(os.path.join(example_path, cli_build_path))

--- a/build_platform.py
+++ b/build_platform.py
@@ -233,7 +233,8 @@ def generate_uf2(example_path):
 
     """
     if ALL_PLATFORMS[platform][1] == None:
-        return 1
+        ColorPrint.print_fail(CROSS)
+        ColorPrint.print_fail("Platform does not support UF2 files, skipping generation...")
     # Convert .hex to .uf2
     cli_build_path = "build/*.*." + fqbn.split(':')[2] + "/*.hex"
     input_file = glob1(os.path.join(example_path, cli_build_path))
@@ -251,8 +252,6 @@ def generate_uf2(example_path):
         ColorPrint.print_fail(CROSS)
         ColorPrint.print_fail(out.decode("utf-8"))
         ColorPrint.print_fail(err.decode("utf-8"))
-        return 1
-    return 0
 
 ################################ Test platforms
 platforms = []
@@ -293,7 +292,7 @@ def test_examples_in_folder(folderpath):
             ColorPrint.print_warn("skipping")
             continue
         if os.path.exists(gen_file_name):
-            ColorPrint.print_info("Generating UF2 after compile.")
+            ColorPrint.print_info("Generate build artifacts.")
             # Download uf2conv.py and dependency if we don't already have it
             cmd = "wget -nc --no-check-certificate http://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2families.json https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2conv.py"
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
@@ -327,7 +326,7 @@ def test_examples_in_folder(folderpath):
                 ColorPrint.print_fail(err.decode("utf-8"))
             if os.path.exists(gen_file_name):
                 ColorPrint.print_info("Generating UF2...")
-                success = generate_uf2(folderpath)
+                generate_uf2(folderpath)
         else:
             ColorPrint.print_fail(CROSS)
             ColorPrint.print_fail(out.decode("utf-8"))


### PR DESCRIPTION
This pull request adds support for exporting compiled examples from CI-Arduino.

Compilation:

- If a `.platform.generate` file is included in the `libraryName/examples` folder, Arduino-CLI will export the compiled example as a `.hex` file. 
- Platforms that support the UF2 file format will additionally pack the .hex into a .uf2 file.
- The arduino-cli version has been updated to v18.3

----

Distribution:

- Repositories that include an upload-artifact step (see below) will attach the `.hex` and `.uf2` files to the build in a .zip file (Example, under "Artifacts": https://github.com/brentru/Adafruit_SI1145_Library/actions/runs/1222715452)

For example, the repository above contains two generation files: `.uno.generate` and `.metro_m4.generate`. The AVR (uno) only produces a .hex file:
![hex_uno_export](https://user-images.githubusercontent.com/322428/132879023-629205f4-bff6-4df9-b611-bbf8742e64a0.png)


And the Metro M4 (SAMD51) produces a .hex and .uf2 file:
![metro_export](https://user-images.githubusercontent.com/322428/132878992-8d801f21-f59c-42c9-8547-4fac9c1afba6.png)

----

To attach the compiled build artifacts to a run, use the [upload-artifact](https://github.com/actions/upload-artifact) GitHub action:
```
    - name: Upload build artifacts
      uses: actions/upload-artifact@v2
      with:
        name: ${{ github.event.repository.name }}.${{ github.sha }}
        path: |
            examples/*/build/*/*.hex
            examples/*/build/*/*.bin
            examples/*/build/*/*.uf2
```