### PR TITLE
Fix ci build with esp32s2 boards

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -168,6 +168,8 @@ def install_platform(platform):
         ColorPrint.print_fail("FAILED to install "+platform)
         exit(-1)
     ColorPrint.print_pass(CHECK)
+    # print installed core version
+    print(os.popen('arduino-cli core list | grep {}'.format(platform)).read(), end='')
 
 def run_or_die(cmd, error):
     print(cmd)

--- a/build_platform.py
+++ b/build_platform.py
@@ -311,12 +311,12 @@ def test_examples_in_folder(folderpath):
 
         if BUILD_WARN:
             if os.path.exists(gen_file_name):
-                cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, '-e', examplepath]
+                cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, '-e', folderpath]
             else:
-                cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, examplepath]
+                cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, folderpath]
         else:
-            cmd = ['arduino-cli', 'compile', '--warnings', 'none', '--export-binaries', '--fqbn', fqbn, examplepath]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+            cmd = ['arduino-cli', 'compile', '--warnings', 'none', '--export-binaries', '--fqbn', fqbn, folderpath]
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         r = proc.wait(timeout=60)
         out = proc.stdout.read()


### PR DESCRIPTION
- esp32s2 boards have been taking ages to build, this is fixed by enable 'shell=True' in popen.  ci built with this PR https://github.com/adafruit/Adafruit_TinyUSB_Arduino/runs/3744226543?check_suite_focus=true#step:6:33
- also print the installed core version for troubleshooting purpose

```
SWITCHING TO esp32:esp32:adafruit_metro_esp32s2
Installing esp32:esp32 ✓
esp32:esp32 2.0.0     2.0.0  esp32
```

- change the input compile input to `folderpath` i.e example directory instead of path to .ino file. Since it is the preferred input of arduino-cli

```
$ arduino-cli compile --help
Compiles Arduino sketches.

Usage:
  arduino-cli compile [flags]

Examples:
  arduino-cli compile -b arduino:avr:uno /home/user/Arduino/MySketch
  arduino-cli compile -b arduino:avr:uno --build-property "build.extra_flags=\"-DMY_DEFINE=\"hello world\"\"" /home/user/Arduino/MySketch
  arduino-cli compile -b arduino:avr:uno --build-property "build.extra_flags=-DPIN=2 \"-DMY_DEFINE=\"hello world\"\"" /home/user/Arduino/MySketch
  arduino-cli compile -b arduino:avr:uno --build-property build.extra_flags=-DPIN=2 --build-property "compiler.cpp.extra_flags=\"-DSSID=\"hello world\"\"" /home/user/Arduino/MySketch
```

@ladyada `def test_examples_in_learningrepo(folderpath):` isn't got updated, since it seems not to be used anymore. Should we remove it ? 
