### PR TITLE
Remove the whole blink example folder

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -40,8 +40,7 @@ IS_LEARNING_SYS = False
 if "Adafruit_Learning_System_Guides" in BUILD_DIR:
     print("Found learning system repo")
     IS_LEARNING_SYS = True
-    os.remove(BUILD_DIR + "/ci/examples/Blink/Blink.ino")
-    os.rmdir(BUILD_DIR + "/ci/examples/Blink")
+    shutil.rmtree(BUILD_DIR + "/ci/examples/Blink")
 elif "METROX-Examples-and-Project-Sketches" in BUILD_DIR:
     print("Found MetroX Examples Repo")
     IS_LEARNING_SYS = True


### PR DESCRIPTION
This started failing in the Learning System Guides when I added `.generate` files:
```
Traceback (most recent call last):
build dir: /home/runner/work/Adafruit_Learning_System_Guides/Adafruit_Learning_System_Guides
  File "/home/runner/work/Adafruit_Learning_System_Guides/Adafruit_Learning_System_Guides/ci/build_platform.py", line 44, in <module>
    os.rmdir(BUILD_DIR + "/ci/examples/Blink")
OSError: [Errno 39] Directory not empty: '/home/runner/work/Adafruit_Learning_System_Guides/Adafruit_Learning_System_Guides/ci/examples/Blink'
Found learning system repo
```