### PR TITLE
Fix positional argument issue with AVR installation call

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -213,7 +213,7 @@ def manually_install_esp32_bsp():
     print(out)
     print("Installed ESP32 BSP from source!")
 
-def install_platform(fqbn, platform_name):
+def install_platform(fqbn, platform_name=None):
     print("Installing", fqbn, end=" ")
     if fqbn == "adafruit:avr":   # we have a platform dep
         install_platform("arduino:avr")


### PR DESCRIPTION
Should fix
```
  File "/home/runner/work/Adafruit_Learning_System_Guides/Adafruit_Learning_System_Guides/ci/build_platform.py", line 219, in install_platform
    install_platform("arduino:avr")
TypeError: install_platform() missing 1 required positional argument: 'platform_name'
```

by making `platform_name` key optional instead of required 