### PR TITLE
Better esp platform names

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -60,8 +60,8 @@ ALL_PLATFORMS={
     "zero" : ["arduino:samd:arduino_zero_native", "0x68ed2b88"],
     "cpx" : ["arduino:samd:adafruit_circuitplayground_m0", "0x68ed2b88"],
     # Espressif
-    "esp8266" : ["esp8266:esp8266:huzzah:eesz=4M3M,xtal=80", None],
-    "esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
+    "feather_esp8266" : ["esp8266:esp8266:huzzah:eesz=4M3M,xtal=80", None],
+    "feather_esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
     "feather_esp32_v2_daily" : ["espressif:esp32:adafruit_feather_esp32_v2", None],
     "magtag" : ["esp32:esp32:adafruit_magtag29_esp32s2", "0xbfdd4eee"],
     "funhouse" : ["esp32:esp32:adafruit_funhouse_esp32s2", "0xbfdd4eee"],

--- a/build_platform.py
+++ b/build_platform.py
@@ -60,6 +60,8 @@ ALL_PLATFORMS={
     "zero" : ["arduino:samd:arduino_zero_native", "0x68ed2b88"],
     "cpx" : ["arduino:samd:adafruit_circuitplayground_m0", "0x68ed2b88"],
     # Espressif
+    "esp8266" : ["esp8266:esp8266:huzzah:eesz=4M3M,xtal=80", None],
+    "esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
     "feather_esp8266" : ["esp8266:esp8266:huzzah:eesz=4M3M,xtal=80", None],
     "feather_esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
     "feather_esp32_v2_daily" : ["espressif:esp32:adafruit_feather_esp32_v2", None],


### PR DESCRIPTION
Adding platform names for `feather_esp8266` and `feather_esp32` which alias `esp8266` and `esp32`

Why? Scripts which resource the platform name (`.arduino-platform`), i.e: `${{ matrix.arduino-platform }}.`, will generate files such as`wippersnapper.esp32.littlefs....bin`. These files do not contain the platform name, only the board name.

I'm adding these as duplicates since we use the `esp8266`/`esp32` platforms across a large # of libraries and this will be non-breaking (and mostly used for wippersnapper)