### PR TITLE
correctly add arduino-cli to PATH

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -25,6 +25,7 @@ mkdir ${HOME}/Arduino/libraries
 
 # install arduino IDE
 export PATH=$PATH:$GITHUB_WORKSPACE/bin
+echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
 arduino-cli config init > /dev/null
 arduino-cli core update-index > /dev/null


### PR DESCRIPTION
minor changes to add arduino-cli $GITHUB_PATH as opposed to export.