### PR TITLE
Update for ESP32 Feather v2

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -64,7 +64,6 @@ ALL_PLATFORMS={
     "esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
     "feather_esp8266" : ["esp8266:esp8266:huzzah:xtal=80,vt=flash,exception=disabled,stacksmash=disabled,ssl=all,mmu=3232,non32xfer=fast,eesz=4M2M,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=115200", None],
     "feather_esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
-    "feather_esp32_v2_daily" : ["espressif:esp32:adafruit_feather_esp32_v2", None],
     "feather_esp32_v2" : ["espressif:esp32:adafruit_feather_esp32_v2", None],
     "magtag" : ["esp32:esp32:adafruit_magtag29_esp32s2", "0xbfdd4eee"],
     "funhouse" : ["esp32:esp32:adafruit_funhouse_esp32s2", "0xbfdd4eee"],

--- a/build_platform.py
+++ b/build_platform.py
@@ -65,6 +65,7 @@ ALL_PLATFORMS={
     "feather_esp8266" : ["esp8266:esp8266:huzzah:xtal=80,vt=flash,exception=disabled,stacksmash=disabled,ssl=all,mmu=3232,non32xfer=fast,eesz=4M2M,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=115200", None],
     "feather_esp32" : ["esp32:esp32:featheresp32:FlashFreq=80", None],
     "feather_esp32_v2_daily" : ["espressif:esp32:adafruit_feather_esp32_v2", None],
+    "feather_esp32_v2" : ["espressif:esp32:adafruit_feather_esp32_v2", None],
     "magtag" : ["esp32:esp32:adafruit_magtag29_esp32s2", "0xbfdd4eee"],
     "funhouse" : ["esp32:esp32:adafruit_funhouse_esp32s2", "0xbfdd4eee"],
     "metroesp32s2" : ["esp32:esp32:adafruit_metro_esp32s2", "0xbfdd4eee"],


### PR DESCRIPTION
The Adafruit Feather ESP32 v2 was included in ESP32 Arduino 2.0.3-RC1 release, removing `_daily` suffix from the feather esp32 v2's key as we no longer need to build from arduino-esp32's `master` branch