### PR TITLE
Add Feather ESP32-S3, QT Py ESP32-S3

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -71,6 +71,8 @@ ALL_PLATFORMS={
     "qtpy_esp32s2" : ["esp32:esp32:adafruit_qtpy_esp32s2", "0xbfdd4eee"],
     "feather_esp32s2" : ["esp32:esp32:adafruit_feather_esp32s2", "0xbfdd4eee"],
     "feather_esp32s2_tft" : ["esp32:esp32:adafruit_feather_esp32s2_tft", "0xbfdd4eee"],
+    "feather_esp32s3" : ["esp32:esp32:adafruit_feather_esp32s3", "0xc47e5767"],
+    "qtpy_esp32s3" : ["esp32:esp32:adafruit_qtpy_esp32s3", "0xc47e5767"],
     # Adafruit AVR
     "trinket_3v" : ["adafruit:avr:trinket3", None],
     "trinket_5v" : ["adafruit:avr:trinket5", None],


### PR DESCRIPTION
Adding support for Feather ESP32-S3 and QT Py ESP32-S3

ESP32-S3 Board Family ID from https://github.com/microsoft/uf2/blob/master/utils/uf2families.json#L158