### PR TITLE
Fix AVR platforms not compiling 

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -221,7 +221,7 @@ def manually_install_esp32_bsp(repo_info):
 def install_platform(fqbn, full_platform_name=None):
     print("Installing", fqbn, end=" ")
     if fqbn == "adafruit:avr":   # we have a platform dep
-        install_platform("arduino:avr")
+        install_platform("arduino:avr", full_platform_name)
     if full_platform_name[2] is not None:
         manually_install_esp32_bsp(full_platform_name[2]) # build esp32 bsp from desired source and branch
     if os.system("arduino-cli core install "+fqbn+" --additional-urls "+BSP_URLS+" > /dev/null") != 0:


### PR DESCRIPTION
Fixes AVR platforms not compiling due to https://github.com/adafruit/ci-arduino/pull/132.

Tested locally against the Adafruit Learning System repo with feather32u4 and gemma platforms.

@ladyada  We may want to add the following platforms: adafruit:avr, esp32s2, esp32c3, esp32s3 to https://github.com/adafruit/ci-arduino/blob/master/.github/workflows/githubci.yml#L19 in the future.