### PR TITLE
reordered the actions, so clang-format and doxygen are run first

### DIFF
--- a/example_actions.yml
+++ b/example_actions.yml
@@ -19,14 +19,14 @@ jobs:
     - name: pre-install
       run: bash ci/actions_install.sh
 
-    - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
-
     - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
+      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
     - name: doxygen
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         PRETTYNAME : "Adafruit Arduino Library"
       run: bash ci/doxy_gen_and_deploy.sh
+
+    - name: test platforms
+      run: python3 ci/build_platform.py main_platforms

--- a/example_actions.yml
+++ b/example_actions.yml
@@ -16,17 +16,17 @@ jobs:
          repository: adafruit/ci-arduino
          path: ci
 
-    - name: pre-install
+    - name: Install the prerequisites
       run: bash ci/actions_install.sh
 
-    - name: clang
+    - name: Check for correct code formatting with clang-format
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
-    - name: doxygen
+    - name: Check for correct documentation with doxygen
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         PRETTYNAME : "Adafruit Arduino Library"
       run: bash ci/doxy_gen_and_deploy.sh
 
-    - name: test platforms
+    - name: Test the code on supported platforms
       run: python3 ci/build_platform.py main_platforms


### PR DESCRIPTION
This change reorders the actions so the least expensive and most failing actions are run first. On a typical run, doxygen and clang-format take each about 2s, the complete building on all the supported platforms 10 minutes. In my experience, the most fails I get are from formatting and documentation errors, not from compilation problems. This gives the users a much faster feedback on needed changes in their commits and PRs and shaves off a lot of execution time.

If you also consider accepting PR #135, this gives the user feedback on formatting and documentation in under 30s, compared to before after 13 minutes.
![Screenshot_20220430_185038](https://user-images.githubusercontent.com/48175951/166114855-65f06a82-e49b-44e5-a3e4-7b21ea69a9ce.png)