### PR TITLE
removed the use of apt-spy2

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -3,13 +3,6 @@
 set -e
 
 pip3 install clint pyserial setuptools adafruit-nrfutil
-sudo gem install apt-spy2
-sudo apt-spy2 check
-sudo apt-spy2 fix --commit
-
-# after selecting a specific mirror, we need to run 'apt-get update'
-sudo apt-get -o Acquire::Retries=3 update
-
 sudo apt-get -o Acquire::Retries=3 install -y libllvm8 -V
 
 sudo apt install -fy cppcheck clang-format-8


### PR DESCRIPTION
I'm honest, I have no idea what apt-spy2 does, a quick recherche says something about keeping the `/etc/sources.list` current and the log shows a lot of mirrors which aparently get tested. Shouldn't that be the responsibility of github by having quick download mirrors already configured in their images? Also even using the slowest mirror is faster than the two minutes this test takes.

Here are two runs: This commit lowers the runtime of `pre-install` from 2:31 minutes to 17 seconds, which is 888% faster.
![Screenshot_20220429_085028](https://user-images.githubusercontent.com/48175951/166114853-2756477d-7bac-4baa-9240-716ff7d3eac4.png)
![Screenshot_20220430_185038](https://user-images.githubusercontent.com/48175951/166114855-65f06a82-e49b-44e5-a3e4-7b21ea69a9ce.png)