### PR TITLE
Only install clang-format if it is really missing

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -3,17 +3,20 @@
 set -e
 
 pip3 install clint pyserial setuptools adafruit-nrfutil
-sudo gem install apt-spy2
-sudo apt-spy2 check
-sudo apt-spy2 fix --commit
 
-# after selecting a specific mirror, we need to run 'apt-get update'
-sudo apt-get -o Acquire::Retries=3 update
-
-sudo apt-get -o Acquire::Retries=3 install -y libllvm8 -V
-
-sudo apt install -fy cppcheck clang-format-8
+# Only install stuff if it is really missing. This should never be executed,
+# as the default image contains clang-format v10, v11 (default) and v12.
+# https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#language-and-runtime
 if [ ! -f /usr/bin/clang-format ]; then
+    sudo gem install apt-spy2
+    sudo apt-spy2 check
+    sudo apt-spy2 fix --commit
+
+    # after selecting a specific mirror, we need to run 'apt-get update'
+    sudo apt-get -o Acquire::Retries=3 update
+
+    sudo apt-get -o Acquire::Retries=3 install -y clang-format-8 libllvm8
+
     sudo ln -s /usr/bin/clang-format-8 /usr/bin/clang-format
 fi
 


### PR DESCRIPTION
As the default image already has v10, v11 (default) and v12 installed, you don't have to install v8 and don't even use it. This removes the need for a long (most of the time 2 minutes) mirror search or even call `apt-get install` in the first place. This shortens the time spent in `actions_install.sh` from about 2:30min to 6s, which is 25x faster.

This is similar to PR #135, but wraps it in a conditional: if the search for `/usr/bin/clang-format` fails, install it. This should be fully backwards compatible.

This is the output of `clang-format --version` with this change:
![Screenshot_20220501_201159](https://user-images.githubusercontent.com/48175951/166158907-52dd60e4-d589-4105-8fc2-7055e1ec87a6.png)

This as it was before:
![Screenshot_20220501_201122](https://user-images.githubusercontent.com/48175951/166158917-48fdc717-cf81-46a6-ac55-a081754f2c8b.png)

There is no difference, as both times the defaut `clang-format` gets used.