### PR TITLE
Build for Adafruit QT Py ESP32 Pico

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -73,6 +73,7 @@ ALL_PLATFORMS={
     "feather_esp32s2_tft" : ["esp32:esp32:adafruit_feather_esp32s2_tft", "0xbfdd4eee", None],
     "feather_esp32s3" : ["esp32:esp32:adafruit_feather_esp32s3", "0xc47e5767", None],
     "qtpy_esp32s3" : ["esp32:esp32:adafruit_qtpy_esp32s3", "0xc47e5767", None],
+    "qtpy_esp32" : ["esp32:esp32:adafruit_qtpy_esp32_pico", None, None],
     # Adafruit AVR
     "trinket_3v" : ["adafruit:avr:trinket3", None, None],
     "trinket_5v" : ["adafruit:avr:trinket5", None, None],


### PR DESCRIPTION
Adding build support for [Adafruit QT Py ESP32 Pico](https://www.adafruit.com/product/5395).

Tested locally against WipperSnapper Arduino Library