### PR TITLE
Add Adafruit QT Py ESP32-C3

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -76,6 +76,7 @@ ALL_PLATFORMS={
     "feather_esp32s3_tft" : ["espressif:esp32:adafruit_feather_esp32s3_tft", "0xc47e5767", "adafruit/master"],
     "qtpy_esp32s3" : ["esp32:esp32:adafruit_qtpy_esp32s3", "0xc47e5767", None],
     "qtpy_esp32" : ["esp32:esp32:adafruit_qtpy_esp32_pico", None, None],
+    "qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio", None, None],
     # Adafruit AVR
     "trinket_3v" : ["adafruit:avr:trinket3", None, None],
     "trinket_5v" : ["adafruit:avr:trinket5", None, None],


### PR DESCRIPTION
Adding QT Py ESP32-C3

Notes:
Flash mode is defined as QIO, temporarily fixing an issue with LittleFS corruption (see: https://github.com/espressif/arduino-esp32/issues/6579). I will update ci-arduino to remove this from the FQBN once EspressIf patches and releases this fix.