### PR TITLE
throw warnings if action_install.sh is used and repo does not have 'arduino-library' tag in its topic

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: pre-install

--- a/actions_install.sh
+++ b/actions_install.sh
@@ -32,3 +32,12 @@ echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
 arduino-cli config init > /dev/null
 arduino-cli core update-index > /dev/null
+
+# warn if this library does not have arduino-library tag in its topic
+if [ $GITHUB_REPOSITORY != "adafruit/ci-arduino" ]; then
+  repo_topics=$(curl --request GET --url "https://api.github.com/repos/$GITHUB_REPOSITORY" | jq -r '.topics[]' | xargs)
+  if [[ ! $repo_topics =~ "arduino-library" ]]; then
+    echo "::warning::arduino-library is not found in this repo topics. Please add this tag in repo About"
+  fi
+fi
+


### PR DESCRIPTION
Since rebuild trigger workflow use `arduino-library` tag in topics to determine which repo is an Arduino Library. Although I manually added this tag for all of our repo, I could miss several and/or it is easy for us to forget add this when making an new repo/lib.

This PR will throw an warning if action_install.sh is used by other repo and the repo does not have `arduino-library` in its topic. e.g

![Screenshot from 2022-10-28 16-44-51](https://user-images.githubusercontent.com/249515/198561184-b276ab76-d13d-4441-b838-c757a73079cf.png)

This hopefully over time will help us to get all repo tagged and triggered.