### PR TITLE
Added Arduino Pi Pico platform.

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -167,7 +167,7 @@ ALL_PLATFORMS={
     "attiny806" : ["megaTinyCore:megaavr:atxy6:chip=806", None, None],
     # groupings
     "main_platforms" : ("uno", "leonardo", "mega2560", "zero", "qtpy_m0",
-                        "esp8266", "esp32", "metro_m4", "trinket_m0", "pi_pico"),
+                        "esp8266", "esp32", "metro_m4", "trinket_m0"),
     "arcada_platforms" : ("pybadge", "pygamer", "hallowing_m4",
                           "cpb", "cpx_ada"),
     "wippersnapper_platforms" : ("metro_m4_airliftlite_tinyusb", "pyportal_tinyusb"),


### PR DESCRIPTION
Support for testing examples against the Arduino Pi Pico was added by extending the `ALL_PLATFORMS` collection in `build_platforms.py`. The new key, `pi_pico`, was added to `main_platforms` so it is included by default. Tested by [running the tests](https://github.com/Megunolink/MLP/actions/runs/5001848058) on our Arduino library. 

