### PR TITLE
Fix FAILED to update core indices 

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -175,7 +175,7 @@ ALL_PLATFORMS={
     "rp2040_platforms" : ("pico_rp2040", "feather_rp2040")
 }
 
-BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,http://drazzy.com/package_drazzy.com_index.json"
+BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://gist.githubusercontent.com/brentru/b8aa484c145da9de4b2d2e315c1b6fb1/raw/d8e1da60851d170b2be04775ebe8d2200861324a/package_drazzy.com_index.json"
 
 class ColorPrint:
 


### PR DESCRIPTION
* Temporarily using a gist for the latest (05/04/23) archive of `package_drazzy.com_index.json` hosted on https://web.archive.org/web/20230504110614/http://drazzy.com/package_drazzy.com_index.json

Related issue: https://github.com/SpenceKonde/megaTinyCore/issues/968

Failing: https://github.com/adafruit/Adafruit_LvGL_Glue/actions/runs/5204831513/jobs/9389611039#step:7:20