### PR TITLE
Update pico flash params

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -155,7 +155,7 @@ ALL_PLATFORMS={
     "pico_rp2040" : ["rp2040:rp2040:rpipico:freq=125,flash=2097152_0", "0xe48bff56", None],
     "pico_rp2040_tinyusb" : ["rp2040:rp2040:rpipico:flash=2097152_0,freq=125,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
     "picow_rp2040" : ["rp2040:rp2040:rpipicow:flash=2097152_0,freq=125", "0xe48bff56", None],
-    "picow_rp2040_tinyusb" : ["rp2040:rp2040:rpipicow:flash=2097152_0,freq=133,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
+    "picow_rp2040_tinyusb" : ["rp2040:rp2040:rpipicow:flash=2097152_131072,freq=133,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
     "feather_rp2040" : ["rp2040:rp2040:adafruit_feather:freq=125,flash=8388608_0", "0xe48bff56", None],
     "feather_rp2040_tinyusb" : ["rp2040:rp2040:adafruit_feather:flash=8388608_0,freq=125,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
     "feather_rp2040_rfm" : ["rp2040:rp2040:adafruit_feather_rfm:freq=125,flash=8388608_0", "0xe48bff56", None],


### PR DESCRIPTION
@brentru I was getting flashing errors using the latest CI builds for the PicoW, but v71 (using old CI) works. 
It appears we don't have a storage partition so I've updated the flash defs, also doing the frequencies while at it (133MHz is top before overclocking).

I did the 8mb boards too, but maybe I should restrict my changes to the tiny_usb definitions of flash partitions, and all rp2040 frequencies.