### PR TITLE
Hack fix for arduino-cli issue with megatinycore BSP URL

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -285,6 +285,12 @@ ColorPrint.print_info('#'*40)
 
 run_or_die("arduino-cli core update-index --additional-urls "+BSP_URLS+
            " > /dev/null", "FAILED to update core indices")
+##### HACK !!!!!!!!!!!!!!!!!!!
+# manual fix for megatinycore URL truncation issue
+# see: https://github.com/arduino/arduino-cli/issues/2345
+#      https://github.com/SpenceKonde/megaTinyCore/issues/1005
+os.system("mv ~/.arduino15/package_drazzy.json ~/.arduino15/package_drazzy.com_index.json")
+##### HACK !!!!!!!!!!!!!!!!!!!!
 print()
 
 ################################ Install dependencies


### PR DESCRIPTION
This is hack to get around an issue with the current version of `arduino-cli` that mangles some BSP URLs:
https://github.com/arduino/arduino-cli/issues/2345

This PR uses the suggested fix from:
https://github.com/SpenceKonde/megaTinyCore/issues/1005
to simply rename to file to its expected name.