### PR TITLE
Swap esp32-dev BSP for stable

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -62,7 +62,7 @@ CROSS = u'\N{cross mark}'
 CHECK = u'\N{check mark}'
 
 
-BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,http://drazzy.com/package_drazzy.com_index.json"
+BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,http://drazzy.com/package_drazzy.com_index.json"
 
 class ColorPrint:
 


### PR DESCRIPTION
This swaps the ESP32 Board support package from the `dev` version to the stable version.
Temporarily resolves the CI errors related to 3.0.0-alpha (uses IDF 5.1)

@ladyada
Planning to eventually move WipperSnapper to idf5.1, but currently builds are broken since the 3-alpha arduino-esp32 release last week.