### PR TITLE
Fix "arduino-library" Topic Detection

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -37,9 +37,14 @@ arduino-cli core update-index > /dev/null
 case "$GITHUB_REPOSITORY" in
 (*/ci-arduino|*/Adafruit_Learning_System_Guides) ;;
 (*)
-  repo_topics=$($(curl --request GET --url "https://api.github.com/repos/$GITHUB_REPOSITORY" || []) | jq -r '.topics[]')
-  if [[ ! $repo_topics =~ "arduino-library" ]]; then
-    echo "::warning::arduino-library is not found in this repo topics. Please add this tag in repo About"
+  tmp_file=$(mktemp)
+  http_code=$(curl --silent --write-out "%{http_code}" --output "$tmp_file" --request GET --url "https://api.github.com/repos/$GITHUB_REPOSITORY")
+  if [[ ${http_code} -eq 200 ]]; then
+    repo_topics=$(< "$tmp_file" jq -r '.topics[]')
+    if [[ ! $repo_topics =~ "arduino-library" ]]; then
+      echo "::warning::arduino-library is not found in this repo topics. Please add this tag in repo About"
+    fi
   fi
+  rm "$tmp_file"
 esac
 


### PR DESCRIPTION
Fixes #178 
The bug was probably introduced in PR #171 

This PR fixes the detection if the topic "arduino-library" is present. This fixed code creates a temporary file where the Github API response is written. If the status code is 200 (ok), the repository is public and the temporary file contains the entire response. If the repository does not exist or is private, the status code is 404 (not found). In this first case, the content of the temporary file is parsed to check whether the arduino-library topic exists.