### PR TITLE
Add ItsyBitsy RP2040 and FunHouse_NoOTA targets, fix repo_topics, include RevTFT S3 feather in debug builds

### DIFF
--- a/actions_install.sh
+++ b/actions_install.sh
@@ -37,7 +37,8 @@ arduino-cli core update-index > /dev/null
 case "$GITHUB_REPOSITORY" in
 (*/ci-arduino|*/Adafruit_Learning_System_Guides) ;;
 (*)
-  repo_topics=$($(curl --request GET --url "https://api.github.com/repos/$GITHUB_REPOSITORY" || []) | jq -r '.topics[]')
+  repo_topics=$(curl -f --request GET --url "https://api.github.com/repos/$GITHUB_REPOSITORY" || echo '{"topics":[]}')
+  repo_topics=$(echo $repo_topics | jq -r '.topics[]' )
   if [[ ! $repo_topics =~ "arduino-library" ]]; then
     echo "::warning::arduino-library is not found in this repo topics. Please add this tag in repo About"
   fi

--- a/all_platforms.py
+++ b/all_platforms.py
@@ -16,6 +16,7 @@ ALL_PLATFORMS={
     ## ESP32-S2
     "magtag" : ["esp32:esp32:adafruit_magtag29_esp32s2", "0xbfdd4eee", None],
     "funhouse" : ["esp32:esp32:adafruit_funhouse_esp32s2", "0xbfdd4eee", None],
+    "funhouse_noota" : ["esp32:esp32:adafruit_funhouse_esp32s2:PartitionScheme=tinyuf2_noota", "0xbfdd4eee", None],
     "metroesp32s2" : ["esp32:esp32:adafruit_metro_esp32s2", "0xbfdd4eee", None],
     "qtpy_esp32s2" : ["esp32:esp32:adafruit_qtpy_esp32s2", "0xbfdd4eee", None],
     "feather_esp32s2" : ["esp32:esp32:adafruit_feather_esp32s2", "0xbfdd4eee", None],

--- a/all_platforms.py
+++ b/all_platforms.py
@@ -31,6 +31,7 @@ ALL_PLATFORMS={
     "feather_esp32s3_tft" : ["esp32:esp32:adafruit_feather_esp32s3_tft", "0xc47e5767", None],
     "feather_esp32s3_tft_debug" : ["esp32:esp32:adafruit_feather_esp32s3_tft:DebugLevel=verbose", "0xc47e5767", None],
     "feather_esp32s3_reverse_tft" : ["esp32:esp32:adafruit_feather_esp32s3_reversetft", "0xc47e5767", None],
+    "feather_esp32s3_reverse_tft_debug" : ["esp32:esp32:adafruit_feather_esp32s3_reversetft:DebugLevel=verbose", "0xc47e5767", None],
     "matrixportal_s3" : ["esp32:esp32:adafruit_matrixportal_esp32s3", "0xc47e5767", None],
     "metro_esp32s3" : ["esp32:esp32:adafruit_metro_esp32s3", "0xc47e5767", None],
     "pycamera_s3" : ["espressif:esp32:adafruit_camera_esp32s3", "0xc47e5767", "espressif/master"],

--- a/all_platforms.py
+++ b/all_platforms.py
@@ -117,6 +117,8 @@ ALL_PLATFORMS={
     "qt2040_trinkey_tinyusb" : ["rp2040:rp2040:adafruit_trinkeyrp2040qt:flash=8388608_0,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
     "qt_py_rp2040": ["rp2040:rp2040:adafruit_qtpy:freq=125,flash=8388608_0", "0xe48bff56", None],
     "qt_py_rp2040_tinyusb": ["rp2040:rp2040:adafruit_qtpy:flash=8388608_0,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
+    "itsybitsy_rp2040" : ["rp2040:rp2040:adafruit_itsybitsy:freq=125,flash=8388608_524288", "0xe48bff56", None],
+    "itsybitsy_rp2040_tinyusb" : ["rp2040:rp2040:adafruit_itsybitsy:flash=8388608_524288,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
 
     # Attiny8xy, 16xy, 32xy (SpenceKonde)
     "attiny3217" : ["megaTinyCore:megaavr:atxy7:chip=3217", None, None],


### PR DESCRIPTION
This PR:

- adds two itsybitsy_rp2040 definitions, normal + TinyUSB variants of the ItsyBitsy RP2040, both currently setup with 512k assigned to filesystem partition.
- adds FunHouse No OTA definition `funhouse_noota`
- adds ItsyBitsy ESP32 definition
- adds debug entry for adafruit_feather_esp32s3_reversetft.
- fixes an issue with reading the topics of a GH repo if the repo is private/404 when checking for arduino-library