### PR TITLE
Importable build platform

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: pre-install

--- a/build_platform.py
+++ b/build_platform.py
@@ -185,7 +185,7 @@ def install_library_deps():
     print()
 
     # Install dependencies
-    our_name=None
+    our_name = None
     try:
         if IS_LEARNING_SYS:
             libprop = open(BUILD_DIR+'/library.deps')
@@ -406,7 +406,6 @@ def main():
 
     # expand groups:
     for arg in sys.argv[1:]:
-
         platform = ALL_PLATFORMS.get(arg, None)
         if isinstance(platform, list):
             platforms.append(arg)

--- a/build_platform.py
+++ b/build_platform.py
@@ -63,12 +63,12 @@ CROSS = u'\N{cross mark}'
 CHECK = u'\N{check mark}'
 
 BSP_URLS = (
-    "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
-    ",http://arduino.esp8266.com/stable/package_esp8266com_index.json"
-    ",https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
-    ",https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json"
-    ",https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json"
-    ",https://drazzy.good-enough.cloud/package_drazzy.com_index.json"
+    "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,"
+    "http://arduino.esp8266.com/stable/package_esp8266com_index.json,"
+    "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,"
+    "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,"
+    "https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,"
+    "https://drazzy.good-enough.cloud/package_drazzy.com_index.json"
 )
 
 # global exit code

--- a/build_platform.py
+++ b/build_platform.py
@@ -169,7 +169,7 @@ def run_or_die(cmd, error):
 def is_library_installed(lib_name):
     try:
         installed_libs = subprocess.check_output(["arduino-cli", "lib", "list"]).decode("utf-8")
-        return not all(not item for item in [re.match('^'+dep+'\\s*\\d+\\.', line) for line in installed_libs.split('\n')])
+        return not all(not item for item in [re.match('^'+lib_name+'\\s*\\d+\\.', line) for line in installed_libs.split('\n')])
     except subprocess.CalledProcessError as e:
         print("Error checking installed libraries:", e)
         return False

--- a/build_platform.py
+++ b/build_platform.py
@@ -63,12 +63,12 @@ CROSS = u'\N{cross mark}'
 CHECK = u'\N{check mark}'
 
 BSP_URLS = (
-    "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,"
-    "http://arduino.esp8266.com/stable/package_esp8266com_index.json,"
-    "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,"
-    "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,"
-    "https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,"
-    "http://drazzy.com/package_drazzy.com_index.json"
+    "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
+    ",http://arduino.esp8266.com/stable/package_esp8266com_index.json"
+    ",https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
+    ",https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json"
+    ",https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json"
+    #",http://drazzy.com/package_drazzy.com_index.json"
 )
 
 # global exit code

--- a/build_platform.py
+++ b/build_platform.py
@@ -63,7 +63,13 @@ CROSS = u'\N{cross mark}'
 CHECK = u'\N{check mark}'
 
 
-BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json"
+BSP_URLS = (
+    "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,"
+    "http://arduino.esp8266.com/stable/package_esp8266com_index.json,"
+    "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,"
+    "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,"
+    "https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json"
+)
 
 class ColorPrint:
 
@@ -156,16 +162,6 @@ def run_or_die(cmd, error):
     ColorPrint.print_fail(error)
     exit(-1)
 
-################################ Install Arduino IDE
-print()
-ColorPrint.print_info('#'*40)
-print("INSTALLING ARDUINO BOARDS")
-ColorPrint.print_info('#'*40)
-
-run_or_die("arduino-cli core update-index --additional-urls "+BSP_URLS+
-           " > /dev/null", "FAILED to update core indices")
-
-print()
 
 def is_library_installed(lib_name):
     try:
@@ -175,43 +171,54 @@ def is_library_installed(lib_name):
         print("Error checking installed libraries:", e)
         return False
 
-################################ Install dependencies
-our_name=None
-try:
-    if IS_LEARNING_SYS:
-        libprop = open(BUILD_DIR+'/library.deps')
-    else:
-        libprop = open(BUILD_DIR+'/library.properties')
-    for line in libprop:
-        if line.startswith("name="):
-            our_name = line.replace("name=", "").strip()
-        if line.startswith("depends="):
-            deps = line.replace("depends=", "").split(",")
-            for dep in deps:
-                dep = dep.strip()
-                if not is_library_installed(dep):
-                    print("Installing "+dep)
-                    run_or_die('arduino-cli lib install "'+dep+'" > /dev/null',
-                               "FAILED to install dependency "+dep)
-                else:
-                    print("Skipping already installed lib: "+dep)
-except OSError:
-    print("No library dep or properties found!")
-    pass  # no library properties
 
-# Delete the existing library if we somehow downloaded
-# due to dependencies
-if our_name:
-    run_or_die("arduino-cli lib uninstall \""+our_name+"\"", "Could not uninstall")
+def install_library_deps():
+    print()
+    ColorPrint.print_info('#'*40)
+    print("INSTALLING ARDUINO LIBRARIES")
+    ColorPrint.print_info('#'*40)
 
-print("Libraries installed: ", glob.glob(os.environ['HOME']+'/Arduino/libraries/*'))
+    run_or_die("arduino-cli core update-index --additional-urls "+BSP_URLS+
+               " > /dev/null", "FAILED to update core indices")
+    print()
 
-# link our library folder to the arduino libraries folder
-if not IS_LEARNING_SYS:
+    # Install dependencies
+    our_name=None
     try:
-        os.symlink(BUILD_DIR, os.environ['HOME']+'/Arduino/libraries/' + os.path.basename(BUILD_DIR))
-    except FileExistsError:
-        pass
+        if IS_LEARNING_SYS:
+            libprop = open(BUILD_DIR+'/library.deps')
+        else:
+            libprop = open(BUILD_DIR+'/library.properties')
+        for line in libprop:
+            if line.startswith("name="):
+                our_name = line.replace("name=", "").strip()
+            if line.startswith("depends="):
+                deps = line.replace("depends=", "").split(",")
+                for dep in deps:
+                    dep = dep.strip()
+                    if not is_library_installed(dep):
+                        print("Installing "+dep)
+                        run_or_die('arduino-cli lib install "'+dep+'" > /dev/null',
+                                   "FAILED to install dependency "+dep)
+                    else:
+                        print("Skipping already installed lib: "+dep)
+    except OSError:
+        print("No library dep or properties found!")
+        pass  # no library properties
+
+    # Delete the existing library if we somehow downloaded
+    # due to dependencies
+    if our_name:
+        run_or_die("arduino-cli lib uninstall \""+our_name+"\"", "Could not uninstall")
+
+    print("Libraries installed: ", glob.glob(os.environ['HOME']+'/Arduino/libraries/*'))
+
+    # link our library folder to the arduino libraries folder
+    if not IS_LEARNING_SYS:
+        try:
+            os.symlink(BUILD_DIR, os.environ['HOME']+'/Arduino/libraries/' + os.path.basename(BUILD_DIR))
+        except FileExistsError:
+            pass
 
 ################################ UF2 Utils.
 
@@ -292,21 +299,6 @@ def generate_uf2(example_path):
         return None
     return output_file
 
-################################ Test platforms
-platforms = []
-success = 0
-
-# expand groups:
-for arg in sys.argv[1:]:
-    platform = ALL_PLATFORMS.get(arg, None)
-    if isinstance(platform, list):
-        platforms.append(arg)
-    elif isinstance(platform, tuple):
-        for p in platform:
-            platforms.append(p)
-    else:
-        print("Unknown platform: ", arg)
-        exit(-1)
 
 @contextmanager
 def group_output(title):
@@ -411,7 +403,7 @@ def test_examples_in_learningrepo(folderpath):
             continue
         if not projectpath.endswith(".ino"):
             continue
-	    # found an INO!
+        # found an INO!
         print('\t'+projectpath, end=' ', flush=True)
         # check if we should SKIP
         skipfilename = folderpath+"/."+platform+".test.skip"
@@ -441,14 +433,34 @@ def test_examples_in_learningrepo(folderpath):
             success = 1
 
 
-for platform in platforms:
-    fqbn = ALL_PLATFORMS[platform][0]
-    print('#'*80)
-    ColorPrint.print_info("SWITCHING TO "+fqbn)
-    install_platform(":".join(fqbn.split(':', 2)[0:2]), ALL_PLATFORMS[platform]) # take only first two elements
-    print('#'*80)
-    if not IS_LEARNING_SYS:
-        test_examples_in_folder(BUILD_DIR+"/examples")
-    else:
-        test_examples_in_folder(BUILD_DIR)
-exit(success)
+if __name__ == "__main__":
+    # Test platforms
+    platforms = []
+    success = 0
+
+    # expand groups:
+    for arg in sys.argv[1:]:
+        platform = ALL_PLATFORMS.get(arg, None)
+        if isinstance(platform, list):
+            platforms.append(arg)
+        elif isinstance(platform, tuple):
+            for p in platform:
+                platforms.append(p)
+        else:
+            print("Unknown platform: ", arg)
+            exit(-1)
+
+    # Install libraries deps
+    install_library_deps()
+
+    for platform in platforms:
+        fqbn = ALL_PLATFORMS[platform][0]
+        print('#'*80)
+        ColorPrint.print_info("SWITCHING TO "+fqbn)
+        install_platform(":".join(fqbn.split(':', 2)[0:2]), ALL_PLATFORMS[platform]) # take only first two elements
+        print('#'*80)
+        if not IS_LEARNING_SYS:
+            test_examples_in_folder(BUILD_DIR+"/examples")
+        else:
+            test_examples_in_folder(BUILD_DIR)
+    exit(success)


### PR DESCRIPTION
This PR move most of global code and variable into main() function, remove ussage of global fqb/platform/platforms in other funtions. This allow build_platform.py can be immported by other python script. And can run `test_examples_in_folder()` without installing the core platform.

The reason is BSP_URL is using arduino-esp32 dev json --> install esp32 v3.0.0 alpha. Some libraries such as TinyUSB need to run with both v3.0.0 (dev) and v2.0.15 since espressif update libtinyusb often and can cause version mismatch.

This changes allow other lib can manually install arduino core (e.g esp v2) then execute tests as done in https://github.com/adafruit/Adafruit_TinyUSB_Arduino/pull/414/files#diff-4951824edd423ca1a60532c1baf26ddf0b20f04791e15628c1de91c0200051d3R86

also fix is_library_installed() using incorrect parameter (deps undefined)
