### PR TITLE
Add HTTPS mirror of Drazzy.com served through cloudflare

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -63,7 +63,7 @@ CROSS = u'\N{cross mark}'
 CHECK = u'\N{check mark}'
 
 
-BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,http://drazzy.com/package_drazzy.com_index.json"
+BSP_URLS = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,http://arduino.esp8266.com/stable/package_esp8266com_index.json,https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://drazzy.good-enough.cloud/package_drazzy.com_index.json"
 
 class ColorPrint:
 


### PR DESCRIPTION
@ladyada / @caternuson I did this last time to unblock us, instead of removing the Drazzy link, but maybe it can be a long term fix.
This is a domain that I own, with multiple year validity and auto-renew (with account credit and calendar reminders).  
It's DNS is hosted on Cloudflare, and I've created a subdomain using Cloudflare proxy that points at Drazzy.com but using Cloudflare's SSL certificate (zero cost).

https://drazzy.good-enough.cloud (all url paths will forward)
i.e. the new BSP path becomes 
https://drazzy.good-enough.cloud/package_drazzy.com_index.json