### PR TITLE
Update all_platforms.py - set C6 feather to CDC on for WipperSnapper

### DIFF
--- a/all_platforms.py
+++ b/all_platforms.py
@@ -18,7 +18,8 @@ ALL_PLATFORMS={
     "qtpy_esp32" : ["esp32:esp32:adafruit_qtpy_esp32_pico", None, None],
     ## ESP32-C3/C6
     "feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:FlashMode=qio", None, None],
-    "wippersnapper_feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:CDCOnBoot=cdc,DebugLevel=info,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs", None, None],
+    "wippersnapper_feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:CDCOnBoot=cdc,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs", None, None],
+    "wippersnapper_feather_esp32c6_debug" : ["esp32:esp32:adafruit_feather_esp32c6:CDCOnBoot=cdc,DebugLevel=verbose,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs", None, None],
     "qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio", None, None],
     "wippersnapper_qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio,PartitionScheme=min_spiffs", None, None],
     ## ESP32-S2

--- a/all_platforms.py
+++ b/all_platforms.py
@@ -18,7 +18,7 @@ ALL_PLATFORMS={
     "qtpy_esp32" : ["esp32:esp32:adafruit_qtpy_esp32_pico", None, None],
     ## ESP32-C3/C6
     "feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:FlashMode=qio", None, None],
-    "wippersnapper_feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:CDCOnBoot=cdc,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs", None, None],
+    "wippersnapper_feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:CDCOnBoot=cdc,DebugLevel=info,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs", None, None],
     "qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio", None, None],
     "wippersnapper_qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio,PartitionScheme=min_spiffs", None, None],
     ## ESP32-S2

--- a/all_platforms.py
+++ b/all_platforms.py
@@ -18,7 +18,7 @@ ALL_PLATFORMS={
     "qtpy_esp32" : ["esp32:esp32:adafruit_qtpy_esp32_pico", None, None],
     ## ESP32-C3/C6
     "feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:FlashMode=qio", None, None],
-    "wippersnapper_feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:FlashMode=qio,PartitionScheme=min_spiffs", None, None],
+    "wippersnapper_feather_esp32c6" : ["esp32:esp32:adafruit_feather_esp32c6:CDCOnBoot=cdc,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs", None, None],
     "qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio", None, None],
     "wippersnapper_qtpy_esp32c3" : ["esp32:esp32:adafruit_qtpy_esp32c3:FlashMode=qio,PartitionScheme=min_spiffs", None, None],
     ## ESP32-S2


### PR DESCRIPTION
Hey @brentru I've added a couple of build options to the C6 feather wippersnapper build target:
`esp32:esp32:adafruit_feather_esp32c6:UploadSpeed=921600,CDCOnBoot=cdc,CPUFreq=160,FlashFreq=80,FlashMode=qio,PartitionScheme=min_spiffs`