### PR TITLE
change esp32 package json to stable one

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -65,7 +65,8 @@ CHECK = u'\N{check mark}'
 BSP_URLS = (
     "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json,"
     "http://arduino.esp8266.com/stable/package_esp8266com_index.json,"
-    "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json,"
+    #"https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json," # esp32 beta release
+    "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json,"
     "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json,"
     "https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,"
     "https://drazzy.good-enough.cloud/package_drazzy.com_index.json,"


### PR DESCRIPTION
change esp32 package json index from beta to stable (official). Due to an issue with 3.1.0-RC when building with tinysb library. It is fixed in their latest release/v3.1 branch. Also currently we have no need for RC release, I think we historically use it when espressif introduce esp32s2 or so.

merged now for https://github.com/adafruit/Adafruit_TinyUSB_Arduino/pull/466, we can revert this should there is an issue