### PR TITLE
Ci wippersnapper boards local txt

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -479,19 +479,54 @@ def main():
         # Inject boards.local.txt if requested
         if COPY_BOARDS_LOCAL_TXT and boards_local_txt:
             try:
-                # Find platform path via `arduino-cli core list --format json`
+                # Get arduino-cli data directory
                 import json
-                output = subprocess.check_output(["arduino-cli", "core", "list", "--format", "json"]).decode()
-                core_list = json.loads(output)["platforms"]
-                for core in core_list:
-                    if core["id"] == core_fqbn:
-                        platform_path = core["install_dir"]
+                config_output = subprocess.check_output(["arduino-cli", "config", "dump", "--format", "json"]).decode()
+                config = json.loads(config_output)
+                ColorPrint.print_info(f"Using arduino-cli config: {config_output.strip()}")
+                
+                # Extract data directory, with fallback to default
+                data_dir = config.get("directories", {}).get("data", "")
+                if not data_dir:
+                    ColorPrint.print_warn("No data directory found in arduino-cli config, using fallback locations.")
+                    # Fallback to common default locations
+                    if os.name == 'nt':  # Windows
+                        data_dir = os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Arduino15')
+                    else:  # Linux/macOS
+                        data_dir = os.path.join(os.environ.get('HOME', ''), '.arduino15')
+                ColorPrint.print_info(f"Using data directory: {data_dir}")
+
+                # Parse platform vendor and architecture from core_fqbn (e.g., "adafruit:samd")
+                parts = core_fqbn.split(':')
+                if len(parts) >= 2:
+                    vendor = parts[0]
+                    architecture = parts[1]
+                else:
+                    vendor = core_fqbn
+                    architecture = vendor
+
+                ColorPrint.print_info(f"Using vendor: {vendor}, architecture: {architecture}")
+
+                # Construct base platform path
+                platform_base = os.path.join(data_dir, "packages", vendor, "hardware", architecture)
+                
+                # Find the latest version directory
+                if os.path.exists(platform_base):
+                    versions = [d for d in os.listdir(platform_base) if os.path.isdir(os.path.join(platform_base, d))]
+                    ColorPrint.print_info(f"Found versions: {versions}")
+                    if versions:
+                        # Sort versions and take the latest (could be improved with proper version sorting)
+                        latest_version = sorted(versions)[-1]
+                        platform_path = os.path.join(platform_base, latest_version)
+                        
                         dest_path = os.path.join(platform_path, "boards.local.txt")
                         shutil.copyfile(boards_local_txt, dest_path)
                         ColorPrint.print_info(f"Copied boards.local.txt to {dest_path}")
-                        break
+                    else:
+                        ColorPrint.print_warn(f"No version directories found in {platform_base}")
                 else:
-                    ColorPrint.print_warn(f"Could not find platform path for {core_fqbn} - not copying boards.local.txt")
+                    ColorPrint.print_warn(f"Platform path {platform_base} does not exist")
+  
             except Exception as e:
                 ColorPrint.print_fail(f"Error injecting boards.local.txt for {core_fqbn}: {e}")
         print('#'*80)

--- a/build_platform.py
+++ b/build_platform.py
@@ -29,8 +29,8 @@ if "--build_timeout" in sys.argv:
     sys.argv.pop(sys.argv.index("--build_timeout") + 1)
     sys.argv.remove("--build_timeout")
 
-# optional --boards-local-txt option to copy boards.local.txt
-# to the appropriate package folder after installing the platform
+# optional --boards-local-txt argument to copy boards.local.txt
+# to the appropriate folder after installing the platform BSP.
 COPY_BOARDS_LOCAL_TXT = False
 boards_local_txt = None
 if "--boards-local-txt" in sys.argv:
@@ -473,10 +473,10 @@ def main():
         fqbn = ALL_PLATFORMS[platform][0]
         print('#'*80)
         ColorPrint.print_info("SWITCHING TO "+fqbn)
-        core_fqbn = ":".join(fqbn.split(':', 2)[0:2])
-        install_platform(core_fqbn, ALL_PLATFORMS[platform])  # take only first two elements
+        core_fqbn = ":".join(fqbn.split(':', 2)[0:2])  # take only first two elements
+        install_platform(core_fqbn, ALL_PLATFORMS[platform])
 
-        # Inject boards.local.txt if enabled
+        # Inject boards.local.txt if requested
         if COPY_BOARDS_LOCAL_TXT and boards_local_txt:
             try:
                 # Find platform path via `arduino-cli core list --format json`

--- a/build_platform.py
+++ b/build_platform.py
@@ -528,21 +528,25 @@ def main():
 
                 # Find the latest version directory
                 if os.path.exists(platform_base):
-                    versions = [d for d in os.listdir(platform_base) if os.path.isdir(os.path.join(platform_base, d))]
-                    ColorPrint.print_info(f"Found versions: {versions}")
-                    if versions:
-                        # Sort versions and take the latest (could be improved with proper version sorting)
-                        latest_version = sorted(versions)[-1]
-                        platform_path = os.path.join(platform_base, latest_version)
-                        
-                        dest_path = os.path.join(platform_path, "boards.local.txt")
-                        shutil.copyfile(boards_local_txt, dest_path)
-                        ColorPrint.print_info(f"Copied boards.local.txt to {dest_path}")
-                    elif os.path.exists(os.path.join(platform_base, "boards.txt")):
+                    if os.path.exists(os.path.join(platform_base, "boards.txt")):
                         shutil.copyfile(boards_local_txt, os.path.join(platform_base, "boards.local.txt"))
                         ColorPrint.print_info(f"Copied boards.local.txt to {os.path.join(platform_base, 'boards.local.txt')}")
                     else:
-                        ColorPrint.print_warn(f"No version directories found in {platform_base}")
+                        versions = [d for d in os.listdir(platform_base) if os.path.isdir(os.path.join(platform_base, d))]
+                        ColorPrint.print_info(f"Found versions: {versions}")
+                        # Filter out non-version directories (e.g., 'tools', 'libraries') while supporting 1.0-dev 1.0.0-offline-mode.102 etc
+                        versions = [v for v in versions if re.match(r'^(v)?\d+\.\d+(\.\d+(-\w+)?)?(\.\d+)?$', v)]
+                        if versions:
+                            # Sort versions and take the latest (could be improved with proper version sorting)
+                            latest_version = sorted(versions)[-1]
+                            platform_path = os.path.join(platform_base, latest_version)
+                            
+                            dest_path = os.path.join(platform_path, "boards.local.txt")
+                            shutil.copyfile(boards_local_txt, dest_path)
+                            ColorPrint.print_info(f"Copied boards.local.txt to {dest_path}")
+
+                        else:
+                            ColorPrint.print_warn(f"No version directories found in {platform_base}")
                 else:
                     ColorPrint.print_warn(f"Platform path {platform_base} does not exist")
   

--- a/build_platform.py
+++ b/build_platform.py
@@ -418,6 +418,8 @@ def test_examples_in_folder(platform, folderpath):
             elif os.path.exists(folderpath+"/boards.local.txt"):
                 ColorPrint.print_info("Copying boards.local.txt from "+folderpath+"/boards.local.txt")
                 install_boards_local_txt(":".join(fqbn.split(':')[0:2]), folderpath+"/boards.local.txt")
+            else:
+                ColorPrint.print_info("No example-specific boards.local.txt found to copy, using root version")
 
         if BUILD_WARN:
             if os.path.exists(gen_file_name):

--- a/build_platform.py
+++ b/build_platform.py
@@ -29,6 +29,28 @@ if "--build_timeout" in sys.argv:
     sys.argv.pop(sys.argv.index("--build_timeout") + 1)
     sys.argv.remove("--build_timeout")
 
+# optional --boards-local-txt option to copy boards.local.txt
+# to the appropriate package folder after installing the platform
+COPY_BOARDS_LOCAL_TXT = False
+boards_local_txt = None
+if "--boards-local-txt" in sys.argv:
+    COPY_BOARDS_LOCAL_TXT = True
+    if sys.argv.index("--boards-local-txt") + 1 >= len(sys.argv):
+        # check if in cwd
+        if os.path.exists("boards.local.txt"):
+            boards_local_txt = "boards.local.txt"
+        else:
+            sys.stderr.write("Error: --boards-local-txt option requires a path to boards.local.txt file\n")
+            sys.exit(1)
+    else:
+        # get the boards.local.txt file from the command line
+        if not os.path.exists(sys.argv[sys.argv.index("--boards-local-txt") + 1]):
+            sys.stderr.write("Error: boards.local.txt file does not exist\n")
+            sys.exit(1)
+        boards_local_txt = sys.argv[sys.argv.index("--boards-local-txt") + 1]
+        sys.argv.pop(sys.argv.index("--boards-local-txt") + 1)
+    sys.argv.remove("--boards-local-txt")
+
 # add user bin to path!
 BUILD_DIR = ''
 # add user bin to path!

--- a/build_platform.py
+++ b/build_platform.py
@@ -482,7 +482,7 @@ def main():
                 # Find platform path via `arduino-cli core list --format json`
                 import json
                 output = subprocess.check_output(["arduino-cli", "core", "list", "--format", "json"]).decode()
-                core_list = json.loads(output)
+                core_list = json.loads(output)["platforms"]
                 for core in core_list:
                     if core["id"] == core_fqbn:
                         platform_path = core["install_dir"]

--- a/build_platform.py
+++ b/build_platform.py
@@ -519,8 +519,13 @@ def main():
                 # Construct base platform path, fall back to architecture if vendor rebadged BSP.
                 platform_base = os.path.join(data_dir, "packages", vendor, "hardware", architecture) if \
                     os.path.exists(os.path.join(data_dir, "packages", vendor, "hardware", architecture)) else \
-                    os.path.join(data_dir, "packages", architecture, "hardware", architecture)
-                
+                    os.path.join(data_dir, "packages", architecture, "hardware", architecture) if \
+                    os.path.exists(os.path.join(data_dir, "packages", architecture, "hardware", architecture)) else \
+                    os.path.join(data_dir, "hardware", vendor, architecture) if \
+                    os.path.exists(os.path.join(data_dir, "hardware", vendor, architecture)) else \
+                    os.path.join(data_dir, "hardware",
+                                 architecture, architecture)
+
                 # Find the latest version directory
                 if os.path.exists(platform_base):
                     versions = [d for d in os.listdir(platform_base) if os.path.isdir(os.path.join(platform_base, d))]
@@ -533,6 +538,9 @@ def main():
                         dest_path = os.path.join(platform_path, "boards.local.txt")
                         shutil.copyfile(boards_local_txt, dest_path)
                         ColorPrint.print_info(f"Copied boards.local.txt to {dest_path}")
+                    elif os.path.exists(os.path.join(platform_base, "boards.txt")):
+                        shutil.copyfile(boards_local_txt, os.path.join(platform_base, "boards.local.txt"))
+                        ColorPrint.print_info(f"Copied boards.local.txt to {os.path.join(platform_base, 'boards.local.txt')}")
                     else:
                         ColorPrint.print_warn(f"No version directories found in {platform_base}")
                 else:

--- a/build_platform.py
+++ b/build_platform.py
@@ -409,17 +409,23 @@ def test_examples_in_folder(platform, folderpath):
         if os.path.exists(gen_file_name):
             ColorPrint.print_info("generating")
 
-        # check if boards.local.txt should be copied
+
+        # check if root or example-specific boards.local.txt should be copied
         if COPY_BOARDS_LOCAL_TXT:
-            boards_local_txt = folderpath+"/."+platform+".boards.local.txt"
-            if os.path.exists(boards_local_txt):
-                ColorPrint.print_info("Copying boards.local.txt from "+boards_local_txt)
-                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), boards_local_txt)
-            elif os.path.exists(folderpath+"/boards.local.txt"):
-                ColorPrint.print_info("Copying boards.local.txt from "+folderpath+"/boards.local.txt")
-                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), folderpath+"/boards.local.txt")
-            else:
+            root_boards_local_txt = boards_local_txt
+            example_boards_local_txt = folderpath+"/boards.local.txt"
+            board_specific_example_boards_local_txt = folderpath+"/."+platform+".boards.local.txt"
+
+            if os.path.exists(board_specific_example_boards_local_txt):
+                ColorPrint.print_info("Copying boards.local.txt from "+board_specific_example_boards_local_txt)
+                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), board_specific_example_boards_local_txt)
+            elif os.path.exists(example_boards_local_txt):
+                ColorPrint.print_info("Copying boards.local.txt from "+example_boards_local_txt)
+                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), example_boards_local_txt)
+            else: # effectively does the revert if subsequent example doesn't have a specific boards.local.txt
                 ColorPrint.print_info("No example-specific boards.local.txt found to copy, using root version")
+                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), root_boards_local_txt)
+
 
         if BUILD_WARN:
             if os.path.exists(gen_file_name):
@@ -475,9 +481,9 @@ def install_boards_local_txt(core_fqbn, boards_local_txt):
       name, vendor:architecture (e.g., "adafruit:samd").
     :param str boards_local_txt: The path to the boards.local.txt file.
     """
+    local_app_data_dir = os.environ.get('HOME', '')
+    data_dir = None
     try:
-        local_app_data_dir = os.environ.get('HOME', '')
-        data_dir = None
         if os.path.exists(os.path.join(local_app_data_dir, '.arduino15')):
             data_dir = os.path.join(local_app_data_dir, '.arduino15')
         elif os.path.exists(os.path.join(local_app_data_dir, '.arduino')):

--- a/build_platform.py
+++ b/build_platform.py
@@ -402,6 +402,16 @@ def test_examples_in_folder(platform, folderpath):
         if os.path.exists(gen_file_name):
             ColorPrint.print_info("generating")
 
+        # check if boards.local.txt should be copied
+        if COPY_BOARDS_LOCAL_TXT:
+            boards_local_txt = folderpath+"/."+platform+".boards.local.txt"
+            if os.path.exists(boards_local_txt):
+                ColorPrint.print_info("Copying boards.local.txt from "+boards_local_txt)
+                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), boards_local_txt)
+            elif os.path.exists(folderpath+"/boards.local.txt"):
+                ColorPrint.print_info("Copying boards.local.txt from "+folderpath+"/boards.local.txt")
+                install_boards_local_txt(":".join(fqbn.split(':')[0:2]), folderpath+"/boards.local.txt")
+
         if BUILD_WARN:
             if os.path.exists(gen_file_name):
                 cmd = ['arduino-cli', 'compile', '--warnings', 'all', '--fqbn', fqbn, '-e', folderpath]


### PR DESCRIPTION
Adds support for `--boards-local-txt` argument, with file specified or defaulting to current working directory.
Copies specified file, if found, to the board support package for the platform.

Flag also enables support for `boards.txt.local` file in example/sketch folders, and/or board build target specific `.<platform>.boards.local.txt` in example folders