### PR TITLE
Fix flash size for fruit_jam_tinyusb entry

### DIFF
--- a/all_platforms.py
+++ b/all_platforms.py
@@ -158,7 +158,7 @@ ALL_PLATFORMS={
     "itsybitsy_rp2040_tinyusb" : ["rp2040:rp2040:adafruit_itsybitsy:flash=8388608_524288,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
     "floppsy_rp2040" : ["rp2040:rp2040:adafruit_floppsy:freq=125,flash=16777216_14680064", "0xe48bff56", None],
     "floppsy_rp2040_tinyusb" : ["rp2040:rp2040:adafruit_floppsy:flash=16777216_14680064,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
-    "fruit_jam_tinyusb" : ["rp2040:rp2040:adafruit_fruitjam:arch=arm,flash=16777216_0,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
+    "fruit_jam_tinyusb" : ["rp2040:rp2040:adafruit_fruitjam:arch=arm,flash=16777216_8388608,freq=120,dbgport=Disabled,dbglvl=None,usbstack=tinyusb", "0xe48bff56", None],
     # Attiny8xy, 16xy, 32xy (SpenceKonde)
     "attiny3217" : ["megaTinyCore:megaavr:atxy7:chip=3217", None, None],
     "attiny3216" : ["megaTinyCore:megaavr:atxy6:chip=3216", None, None],


### PR DESCRIPTION
Updates Fruit Jam to use an 8/8MB app/user partition