### PR TITLE
feat: add --skip-uninstall flag to avoid getcwd error in multi-call CI jobs

### DIFF
--- a/build_platform.py
+++ b/build_platform.py
@@ -20,6 +20,12 @@ if "--no_warn" in sys.argv:
     BUILD_WARN = False
     sys.argv.remove("--no_warn")
 
+# optional flag to skip the lib uninstall step
+SKIP_UNINSTALL = False
+if "--skip-uninstall" in sys.argv:
+    SKIP_UNINSTALL = True
+    sys.argv.remove("--skip-uninstall")
+
 # optional timeout argument to extend build time
 # for larger sketches or firmware builds
 BUILD_TIMEOUT = False
@@ -219,7 +225,9 @@ def install_library_deps():
 
     # Delete the existing library if we somehow downloaded
     # due to dependencies
-    if our_name:
+    # Skipped when --skip-uninstall is passed (e.g. when called multiple times
+    # in one CI job to avoid deleting the symlinked checkout dir)
+    if our_name and not SKIP_UNINSTALL:
         run_or_die("arduino-cli lib uninstall \""+our_name+"\"", "Could not uninstall")
 
     print("Libraries installed: ", glob.glob(os.environ['HOME']+'/Arduino/libraries/*'))

--- a/build_platform.py
+++ b/build_platform.py
@@ -22,9 +22,13 @@ if "--no_warn" in sys.argv:
 
 # optional flag to skip the lib uninstall step
 SKIP_UNINSTALL = False
-if "--skip-uninstall" in sys.argv:
+if "--skip-uninstall" in sys.argv or "--skip_uninstall" in sys.argv:
     SKIP_UNINSTALL = True
-    sys.argv.remove("--skip-uninstall")
+    # Remove all occurrences of both spellings for consistency
+    while "--skip-uninstall" in sys.argv:
+        sys.argv.remove("--skip-uninstall")
+    while "--skip_uninstall" in sys.argv:
+        sys.argv.remove("--skip_uninstall")
 
 # optional timeout argument to extend build time
 # for larger sketches or firmware builds


### PR DESCRIPTION
## Problem

When `build_platform.py` is called multiple times sequentially in one CI job (e.g. for different platforms), the `arduino-cli lib uninstall` step inside `install_library_deps()` follows the symlink `~/Arduino/libraries/LibName → GITHUB_WORKSPACE` and **deletes the checkout directory**. This causes `getcwd()` failures on all subsequent calls because the working directory no longer exists.

## Solution

Adds a `--skip-uninstall` CLI flag. When passed, the `arduino-cli lib uninstall` call is skipped entirely, preserving the symlinked checkout directory across multiple invocations.

### Usage

```bash
# First call — normal behavior
python build_platform.py esp32

# Subsequent calls — skip uninstall to avoid deleting checkout dir
python build_platform.py --skip-uninstall esp8266
```

### Changes

- Added `--skip-uninstall` flag parsing (same pattern as `--wall`, `--no_warn`, `--build_timeout`)
- Global `SKIP_UNINSTALL` boolean controls whether the uninstall step runs
- Wrapped the existing uninstall call with `if our_name and not SKIP_UNINSTALL`