### PR TITLE
Update doxygen build

### DIFF
--- a/Doxyfile.default
+++ b/Doxyfile.default
@@ -791,6 +791,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = 
+INPUT                  += "src" 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doxy_gen_and_deploy.sh
+++ b/doxy_gen_and_deploy.sh
@@ -107,7 +107,7 @@ fi
 shopt -s extglob
 if [ ! -f index.html ]; then
     rm -rf *
-    curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/doxy_index.html > index.html
+    curl -SLs https://raw.githubusercontent.com/adafruit/ci-arduino/master/doxy_index.html > index.html
 else
     # Don't fail if there's no files in the directory, just keep going!
     rm -r -- !(index.html) || true
@@ -138,7 +138,7 @@ export DOXYFILE=${BUILD_DIR}/Doxyfile
 if [ ! -f ${DOXYFILE} ]; then
     echo "Grabbing default Doxyfile"
 
-    curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/Doxyfile.default > ${DOXYFILE}
+    curl -SLs https://raw.githubusercontent.com/adafruit/ci-arduino/master/Doxyfile.default > ${DOXYFILE}
     #sed -i "s/^INPUT .*/INPUT = ..\/../"  ${DOXYFILE}
 
     # If we can, fix up the name


### PR DESCRIPTION
This relates to:
https://github.com/adafruit/Adafruit_PM25AQI/issues/20

I think the main issue is the lack of specifying the `src` sub dir so doxy will go there. As a result, the output ends up being empty.

This PR updates the `Doxyfile.default` to include the `src` directory.

It also updates `doxy_gen_and_deploy.sh` to gab related doxy files from **this** repo instead of the older travis ci related one.

Hard to test 100% locally, but simply running doxygen locally with the updated Doxyfile generates expected `html` subdir with content. 